### PR TITLE
DO NOT MERGE: adds list of outputs to BuildResult

### DIFF
--- a/lib/src/build_result.dart
+++ b/lib/src/build_result.dart
@@ -4,6 +4,7 @@
 
 library barback.build_result;
 
+import 'asset/asset_id.dart';
 import 'errors.dart';
 import 'utils.dart';
 
@@ -23,20 +24,23 @@ class BuildResult {
   /// `true` if the build succeeded.
   bool get succeeded => errors.isEmpty;
 
-  BuildResult(Iterable<BarbackException> errors)
+  final Set<AssetId> outputs;
+
+  BuildResult(Iterable<BarbackException> errors, [this.outputs])
       : errors = flattenAggregateExceptions(errors).toSet();
 
   /// Creates a build result indicating a successful build.
   ///
   /// This equivalent to a build result with no errors.
-  BuildResult.success()
-      : this([]);
+  BuildResult.success([Set<AssetId> outputs]) : this([], outputs);
 
   /// Creates a single [BuildResult] that contains all of the errors of
   /// [results].
   factory BuildResult.aggregate(Iterable<BuildResult> results) {
     var errors = unionAll(results.map((result) => result.errors));
-    return new BuildResult(errors);
+    var outputs = unionAll(results.map((result) =>
+        result.outputs != null ? result.outputs : new Set<AssetId>()));
+    return new BuildResult(errors, outputs);
   }
 
   String toString() {

--- a/test/package_graph/add_remove_transform_test.dart
+++ b/test/package_graph/add_remove_transform_test.dart
@@ -20,7 +20,7 @@ main() {
 
     updateTransformers("app", [[new RewriteTransformer("blub", "blab")]]);
     expectAsset("app|foo.blab", "foo.blab");
-    buildShouldSucceed();
+    buildShouldSucceedWithAsset("app|foo.blab");
   });
 
   test("a new transformer is not applied to a non-matching asset", () {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -215,6 +215,17 @@ void buildShouldSucceed() {
   }), completes);
 }
 
+/// Expects that the next [BuildResult] is a build success and that a certain
+/// asset was output.
+void buildShouldSucceedWithAsset(String name) {
+  var id = new AssetId.parse(name);
+  expect(_getNextBuildResult("build should succeed").then((result) {
+    result.errors.forEach(currentSchedule.signalError);
+    expect(result.succeeded, isTrue);
+    expect(result.outputs.any((AssetId assetId) => assetId == id), isTrue);
+  }), completes);
+}
+
 /// Expects that the next [BuildResult] emitted is a failure.
 ///
 /// [matchers] is a list of matchers to match against the errors that caused the


### PR DESCRIPTION
I just wanted to float this as an idea, and here is a proof of concept (obviously more tests would need to be updated etc).

This would be useful for something like source gen, as it needs to actually dump outputs to disk. Otherwise it has to iterate through all outputs after each build and compute the diff with the last run.
