### PR TITLE
Update Doc comment on `newFuture`

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -247,9 +247,8 @@ Future pumpEventQueue([int times=20]) {
   return new Future.delayed(Duration.ZERO, () => pumpEventQueue(times - 1));
 }
 
-/// Like `new Future`, but avoids issue 11911 by using `new Future.value` under
+/// Like [new Future], but avoids dartbug.com/11911 by using async/await under
 /// the covers.
-// TODO(jmesserly): doc comment changed to due 14601.
 Future/*<T>*/ newFuture/*<T>*/(/*=T*/ callback()) async => await callback();
 
 /// Returns a buffered stream that will emit the same values as the stream


### PR DESCRIPTION
It's not clear to me that this method is still necessary - but the
current Doc comment is lying...

- Update to reflect actual implementation
- Change back to [] syntax since the `new` reference is allowed there
  again