### PR TITLE
Track all BuildResults instead of only most recent

### DIFF
--- a/lib/src/graph/package_graph.dart
+++ b/lib/src/graph/package_graph.dart
@@ -64,8 +64,8 @@ class PackageGraph {
   /// [_tryScheduleResult]).
   bool _resultScheduled = false;
 
-  /// The most recent [BuildResult] emitted on [results].
-  BuildResult _lastResult;
+  /// All [BuildResult]s emitted on [results].
+  final _results = <BuildResult>[];
 
   // TODO(nweiz): This can have bogus errors if an error is created and resolved
   // in the space of one build.
@@ -168,9 +168,10 @@ class PackageGraph {
       return new Future.error(error, _lastUnexpectedErrorTrace);
     }
 
-    // If the last build completed with an error, complete the future with it.
-    if (!_lastResult.succeeded) {
-      return new Future.error(BarbackException.aggregate(_lastResult.errors));
+    // If any build completed with an error, complete the future with it.
+    var result = new BuildResult.aggregate(_results);
+    if (!result.succeeded) {
+      return new Future.error(BarbackException.aggregate(result.errors));
     }
 
     // Otherwise, return all of the final output assets.
@@ -261,9 +262,10 @@ class PackageGraph {
       _resultScheduled = false;
       if (_status != NodeStatus.IDLE) return;
 
-      _lastResult = new BuildResult(_accumulatedErrors);
+      var result = new BuildResult(_accumulatedErrors);
       _accumulatedErrors.clear();
-      _resultsController.add(_lastResult);
+      _results.add(result);
+      _resultsController.add(result);
     });
   }
 

--- a/test/package_graph/get_all_assets_test.dart
+++ b/test/package_graph/get_all_assets_test.dart
@@ -7,6 +7,7 @@ library barback.test.barback_test;
 import 'dart:async';
 
 import 'package:barback/barback.dart';
+import 'package:barback/src/utils.dart';
 import 'package:scheduled_test/scheduled_test.dart';
 
 import '../utils.dart';
@@ -76,6 +77,26 @@ main() {
       isTransformerException(equals(BadTransformer.ERROR)),
       isTransformerException(equals(BadTransformer.ERROR))
     ]));
+  });
+
+  test("completes with error after successful build", () {
+    initGraph([
+      "app|foo.txt"
+    ], {
+      "app": [
+        [
+          new BadTransformer(["app|foo.out"])
+        ]
+      ]
+    });
+
+    updateSources(["app|foo.txt"]);
+    schedule(() => pumpEventQueue());
+    updateTransformers("app", [
+      [new RewriteTransformer("blub", "blub")]
+    ]);
+    expectAllAssetsShouldFail(
+        isTransformerException(equals(BadTransformer.ERROR)));
   });
 
   // Regression test.


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/1336

getAllAssets used to check the BuildResult of all cascades but was
changed to check only the last result. Go back to the old behavior since
any Transformer that has an erorr should cause the entire build to
error.