### PR TITLE
Update .status to remove deleted arch simmips

### DIFF
--- a/.status
+++ b/.status
@@ -17,7 +17,7 @@ test/*: Skip
 [ $runtime == vm && $mode == debug]
 build/test/package_graph/repetition_test: Skip  # Times out
 
-[ $runtime == vm && ( $arch == simarm || $arch == simmips ) ]
+[ $runtime == vm && $arch == simarm ]
 build/test/too_many_open_files_test: Skip # 14220
 
 [ $browser ]


### PR DESCRIPTION
The test scripts now check the status files for validity of cpu architecture values.  Simmips was deleted, along with mips support in Dart.