### PR TITLE
Don't use `sync` controller for "results" stream.

### DIFF
--- a/lib/src/graph/package_graph.dart
+++ b/lib/src/graph/package_graph.dart
@@ -39,8 +39,7 @@ class PackageGraph {
   /// If an unexpected error in barback itself occurs, it will be emitted
   /// through this stream's error channel.
   Stream<BuildResult> get results => _resultsController.stream;
-  final _resultsController =
-      new StreamController<BuildResult>.broadcast(sync: true);
+  final _resultsController = new StreamController<BuildResult>.broadcast();
 
   /// A stream that emits any errors from the graph or the transformers.
   ///


### PR DESCRIPTION
When `async` functions start synchronously, a cycle leads to problems with this synchronous stream controller.
We could probably insert delays in other parts of the package, but this looks like a safe place to switch from sync to non-sync.